### PR TITLE
Add X68030 CRT Mode 19 (640x480x4) support for mlterm-x68kgrf.

### DIFF
--- a/doc/en/README.fb
+++ b/doc/en/README.fb
@@ -108,11 +108,12 @@ Framebuffer support
   o You can specify --depth=1 (1bpp) or --depth=4 (4bpp) on NetBSD/luna68k.
   o You can change the screen resolution and depth by fb_resolution option in
     ~/.mlterm/main on NetBSD/x68k. Supported resolutions are 512x512x15
-    512x512x8 768x512x4 768x512x1 1024x768x4 1024x768x1.
+    512x512x8 768x512x4 768x512x1 1024x768x4 1024x768x1 640x480x4.
     fb_resolution=512x512x15
   o Unless you specify --multivram=false or separate_wall_picture=false option
-    in fb_resolution=768x512x4 or 1024x768x4, the wall picture is drawn on Text
-    VRAM instead of Graphic VRAM and scrolling performance will be improved.
+    in fb_resolution=768x512x4, 1024x768x4 or 640x480x4, the wall picture is
+    drawn on Text VRAM instead of Graphic VRAM and scrolling performance will
+    be improved.
 
   (for OpenBSD)
   o Enable following options and rebuild kernel.

--- a/doc/ja/README.fb
+++ b/doc/ja/README.fb
@@ -118,12 +118,12 @@ Framebuffer 対応に関するメモ
     えることができます。
   o NetBSD/x68k では ~/.mlterm/main に次のように指定することで、解像度を変更でき
     ます。サポートする解像度は、512x512x15 512x512x8 768x512x4 768x512x1
-    1024x768x4 1024x768x1 です。
+    1024x768x4 1024x768x1 640x480x4 です。
     fb_resolution=512x512x15
-  o NetBSD/x68k では、fb_resolution=768x512x4 又は 1024x768x4 の場合に、
-    --multivram=false 又は separate_wall_picture=false オプションを指定しなけれ
-    ば、壁紙のみ Text VRAM に (その他は Graphic VRAM) に描画します。これにより、
-    スクロール速度が改善します。
+  o NetBSD/x68k では、fb_resolution=768x512x4、1024x768x4 又は 640x480x4 の場合
+    に、 --multivram=false 又は separate_wall_picture=false オプションを指定しな
+    ければ、壁紙のみ Text VRAM に (その他は Graphic VRAM) に描画します。これによ
+    り、スクロール速度が改善します。
 
   (for OpenBSD)
   o 次の2行を有効にしてカーネルの再構築を行ってください。

--- a/uitoolkit/fb/ui_display_x68kgrf.c
+++ b/uitoolkit/fb/ui_display_x68kgrf.c
@@ -153,6 +153,8 @@ static int open_display(u_int depth) {
                                   {4, 0x24e4 /* Graphic vram is prior to text one. */, 0x0010}};
   fb_reg_conf_t conf_1024_768_4 = {{169, 14, 28, 156, 439, 5, 40, 424, 27, 1050},
                                    {4, 0x24e4 /* Graphic vram is prior to text one. */, 0x0010}};
+  fb_reg_conf_t conf_640_480_4 = {{99, 11, 13, 93, 524, 1, 33, 513, 27, 1047},
+                                   {4, 0x24e4 /* Graphic vram is prior to text one. */, 0x0010}};
   struct rgb_info rgb_info_15bpp = {3, 3, 3, 6, 11, 1};
   struct termios tm;
 
@@ -214,7 +216,11 @@ static int open_display(u_int depth) {
                   orig_reg.crtc.r08, orig_reg.crtc.r20, orig_reg.videoc.r0, orig_reg.videoc.r1,
                   orig_reg.videoc.r2);
 #else
-  orig_reg = conf_768_512_4;
+  if (vinfo.gd_dwidth == 640) {
+    orig_reg = conf_640_480_4;
+  } else {
+    orig_reg = conf_768_512_4;
+  }
   orig_reg.videoc.r2 = 0x20;
 #endif
 
@@ -240,6 +246,11 @@ static int open_display(u_int depth) {
 
         _display.width = _disp.width = 1024;
         _display.height = _disp.height = 768;
+      } else if (fb_width == 640 && fb_height == 480) {
+        conf = &conf_640_480_4;
+
+        _display.width = _disp.width = 640;
+        _display.height = _disp.height = 480;
       } else {
         conf = &conf_768_512_4;
 


### PR DESCRIPTION
Tested on X68030 running NetBSD/x68k 9.1.
https://twitter.com/tsutsuii/status/1325804754857988097
https://twitter.com/tsutsuii/status/1325830049539354626
https://twitter.com/tsutsuii/status/1326171737457795074