### PR TITLE
fix mlterm(1) spelling mistake

### DIFF
--- a/man/mlterm.1
+++ b/man/mlterm.1
@@ -1957,7 +1957,7 @@ Default colors used by mlterm are
 \fBwhite\fR.  and can be overridden here.
 
 For highlighted colors, a name with "hl_" prefix will be automatically searched.
-i.e. for bold read character, "hl_red" is searched instead of "red".
+i.e. for bold red characters, "hl_red" is searched instead of "red".
 
 \fB17\fR - \fB230\fR and \fB232\fR - \fB255\fR in 256 colors can be also overridden.
 


### PR DESCRIPTION
“bold read character” → “bold red characters”
[“read” is not a color and use plural of character]