### PR TITLE
vt_parser.c: xterm-compatible esc seq

### DIFF
--- a/vtemu/vt_parser.c
+++ b/vtemu/vt_parser.c
@@ -4344,7 +4344,7 @@ static char *get_pt_in_esc_seq(
   pt = *str;
 
   while (1) {
-    if ((bel_terminate && **str == CTL_BEL) || (use_c1 && **str == 0x9c)) {
+    if ( (**str < 0x20) || (bel_terminate && **str == CTL_BEL) || (use_c1 && **str == 0x9c)) {
       **str = '\0';
 
       break;


### PR DESCRIPTION
in `get_pt_in_esc_seq` we skip over the U+0000 block control characters 0x00-0x1F for escape sequences, as per xterm.

fixes  #15