### PR TITLE
[decsdm] scrolling/cursor-based-positioning when *sent*

### DIFF
--- a/vtemu/vt_parser.c
+++ b/vtemu/vt_parser.c
@@ -3896,7 +3896,7 @@ static void set_vtmode(vt_parser_t *vt_parser, int mode, int flag) {
 
   case DECMODE_80:
     /* DECSDM */
-    vt_parser->sixel_scrolling = (flag ? 0 : 1);
+    vt_parser->sixel_scrolling = !!flag;
     break;
 
   case DECMODE_95:


### PR DESCRIPTION
Please see https://github.com/dankamongmen/notcurses/issues/1782 for background context. `DECSDM` in MLterm is reversed compared to most terminals I've tested with (e.g. Alacritty, Contour, Kitty, XTerm, and WezTerm).