### PR TITLE
add `vte_terminal_get_scroll_on_output`

### DIFF
--- a/gtk/vte.c
+++ b/gtk/vte.c
@@ -806,7 +806,7 @@ static void line_scrolled_out(void *p /* must be ui_screen_t */
     gtk_adjustment_changed(ADJUSTMENT(terminal));
 #endif
 
-    if (vt_term_is_backscrolling(PVT(terminal)->term) != BSM_STATIC) {
+    if (vte_terminal_get_scroll_on_output(terminal)) {
 #if GTK_CHECK_VERSION(2, 14, 0)
       gtk_adjustment_set_value(ADJUSTMENT(terminal), value + 1);
 #else
@@ -814,7 +814,7 @@ static void line_scrolled_out(void *p /* must be ui_screen_t */
       gtk_adjustment_value_changed(ADJUSTMENT(terminal));
 #endif
     }
-  } else if (vt_term_is_backscrolling(PVT(terminal)->term) == BSM_STATIC && value > 0) {
+  } else if (!vte_terminal_get_scroll_on_output(terminal) && value > 0) {
 #if GTK_CHECK_VERSION(2, 14, 0)
     gtk_adjustment_set_value(ADJUSTMENT(terminal), value - 1);
 #else
@@ -3271,6 +3271,14 @@ void vte_terminal_set_scroll_background(VteTerminal *terminal, gboolean scroll) 
 
 void vte_terminal_set_scroll_on_output(VteTerminal *terminal, gboolean scroll) {
   ui_exit_backscroll_by_pty(scroll);
+}
+
+gboolean vte_terminal_get_scroll_on_output(VteTerminal *terminal) {
+  if (vt_term_is_backscrolling(PVT(terminal)->term) == BSM_STATIC) {
+    return FALSE;
+  } else {
+    return TRUE;
+  }
 }
 
 void vte_terminal_set_scroll_on_keystroke(VteTerminal *terminal, gboolean scroll) {}


### PR DESCRIPTION
Hi,

I've tried to use `mlterm` as a `libvte` engine as advertised in https://github.com/arakiken/mlterm/blob/master/gtk/README.

It works using `gnome-terminal` but fails on e.g. `xfce4-terminal`:
```bash
$ LD_PRELOAD=$MLTERM_PREFIX/lib/libvte-2.91.so gnome-terminal
$ LD_PRELOAD=$MLTERM_PREFIX/lib/libvte-2.91.so xfce4-terminal
xfce4-terminal: symbol lookup error: xfce4-terminal: undefined symbol: vte_terminal_get_scroll_on_output
```

Here is a patch defining `vte_terminal_get_scroll_on_output` (implementation to be discussed maybe: I don't know much of the `mlterm` internals...).