### PR TITLE
Add support for a --role option to define the WM_WINDOW_ROLE property…

### DIFF
--- a/android/jni/ui_display.c
+++ b/android/jni/ui_display.c
@@ -657,7 +657,7 @@ void ui_display_close_all(void) {
 }
 
 int ui_display_show_root(ui_display_t *disp, ui_window_t *root, int x, int y, int hint,
-                         char *app_name, Window parent_window /* Ignored */
+                         char *app_name, char *wm_role, Window parent_window /* Ignored */
                          ) {
   void *p;
 

--- a/gtk/vte_wayland.c
+++ b/gtk/vte_wayland.c
@@ -60,7 +60,7 @@ static void show_root(ui_display_t *disp, GtkWidget *widget) {
 #endif
 
   /* Internally calls create_shm_buffer() and *set_listener */
-  ui_display_show_root(disp, win, 0, 0, 0, class, gdk_wayland_window_get_wl_surface(window));
+  ui_display_show_root(disp, win, 0, 0, 0, class, NULL, gdk_wayland_window_get_wl_surface(window));
 
   /*
    * XXX

--- a/gtk/vte_xlib.c
+++ b/gtk/vte_xlib.c
@@ -499,7 +499,7 @@ static void show_root(ui_display_t *disp, GtkWidget *widget) {
   }
 #endif
 
-  ui_display_show_root(disp, &PVT(terminal)->screen->window, 0, 0, 0, "mlterm", xid);
+  ui_display_show_root(disp, &PVT(terminal)->screen->window, 0, 0, 0, "mlterm", NULL, xid);
 
 #if GTK_CHECK_VERSION(2, 90, 0) && defined(GDK_TYPE_X11_DEVICE_MANAGER_XI2)
   if (is_xinput2) {

--- a/man/mlterm.1
+++ b/man/mlterm.1
@@ -184,6 +184,10 @@ Don't use input method.
 Specify application name. (WM_CLASS property)
 The default is "\fBmlterm\fR".
 .TP
+\fB\-\-role\fR=\fIrole\fR
+Specify application role. (WM_WINDOW_ROLE property)
+The default is undefined.
+.TP
 \fB\-O\fR, \fB\-\-sbmod\fR=\fIvalue\fR
 Specify the side to show a scrollbar.
 \fBleft\fR for left side and \fBright\fR for right side.

--- a/uitoolkit/beos/ui_display.c
+++ b/uitoolkit/beos/ui_display.c
@@ -115,7 +115,7 @@ ui_display_t **ui_get_opened_displays(u_int *num) {
 int ui_display_fd(ui_display_t *disp) { return disp->display->fd; }
 
 int ui_display_show_root(ui_display_t *disp, ui_window_t *root, int x, int y, int hint,
-                         char *app_name, Window parent_window /* Ignored */
+                         char *app_name, char *wm_role, Window parent_window /* Ignored */
                          ) {
   void *p;
 

--- a/uitoolkit/console/ui_display.c
+++ b/uitoolkit/console/ui_display.c
@@ -953,7 +953,7 @@ ui_display_t **ui_get_opened_displays(u_int *num) {
 int ui_display_fd(ui_display_t *disp) { return fileno(disp->display->fp); }
 
 int ui_display_show_root(ui_display_t *disp, ui_window_t *root, int x, int y, int hint,
-                         char *app_name, Window parent_window /* Ignored */
+                         char *app_name, char *wm_role, Window parent_window /* Ignored */
                          ) {
   void *p;
 

--- a/uitoolkit/fb/ui_display.c
+++ b/uitoolkit/fb/ui_display.c
@@ -1454,7 +1454,7 @@ ui_display_t **ui_get_opened_displays(u_int *num) {
 int ui_display_fd(ui_display_t *disp) { return disp->display->fd; }
 
 int ui_display_show_root(ui_display_t *disp, ui_window_t *root, int x, int y, int hint,
-                         char *app_name, Window parent_window /* Ignored */
+                         char *app_name, char *wm_role, Window parent_window /* Ignored */
                          ) {
   void *p;
 

--- a/uitoolkit/quartz/ui_display.c
+++ b/uitoolkit/quartz/ui_display.c
@@ -110,7 +110,7 @@ ui_display_t **ui_get_opened_displays(u_int *num) {
 int ui_display_fd(ui_display_t *disp) { return disp->display->fd; }
 
 int ui_display_show_root(ui_display_t *disp, ui_window_t *root, int x, int y, int hint,
-                         char *app_name, Window parent_window /* Ignored */
+                         char *app_name, char *wm_role, Window parent_window /* Ignored */
                          ) {
   void *p;
 

--- a/uitoolkit/sdl2/ui_display.c
+++ b/uitoolkit/sdl2/ui_display.c
@@ -1003,7 +1003,7 @@ ui_display_t **ui_get_opened_displays(u_int *num) {
 int ui_display_fd(ui_display_t *disp) { return -1; }
 
 int ui_display_show_root(ui_display_t *disp, ui_window_t *root, int x, int y, int hint,
-                         char *app_name, Window parent_window) {
+                         char *app_name, char *wm_role, Window parent_window) {
   void *p;
 
   if (disp->num_roots > 0) {

--- a/uitoolkit/ui_display.h
+++ b/uitoolkit/ui_display.h
@@ -67,7 +67,7 @@ ui_display_t **ui_get_opened_displays(u_int *num);
 int ui_display_fd(ui_display_t *disp);
 
 int ui_display_show_root(ui_display_t *disp, ui_window_ptr_t root, int x, int y, int hint,
-                         char *app_name, Window parent_window);
+                         char *app_name, char *wm_role, Window parent_window);
 
 int ui_display_remove_root(ui_display_t *disp, ui_window_ptr_t root);
 

--- a/uitoolkit/ui_im_candidate_screen.c
+++ b/uitoolkit/ui_im_candidate_screen.c
@@ -958,7 +958,7 @@ ui_im_candidate_screen_t *ui_im_candidate_screen_new(ui_display_t *disp,
   cand_screen->select = select_candidate;
 
   if (!ui_display_show_root(disp, &cand_screen->window, x, y, XValue | YValue,
-                            "mlterm-candidate-window", 0)) {
+                            "mlterm-candidate-window", NULL, 0)) {
 #ifdef DEBUG
     bl_warn_printf(BL_DEBUG_TAG " ui_display_show_root() failed.\n");
 #endif

--- a/uitoolkit/ui_im_status_screen.c
+++ b/uitoolkit/ui_im_status_screen.c
@@ -441,7 +441,7 @@ ui_im_status_screen_t *ui_im_status_screen_new(ui_display_t *disp, ui_font_manag
   stat_screen->set = set;
 
   if (!ui_display_show_root(disp, &stat_screen->window, x, y, XValue | YValue,
-                            "mlterm-status-window", 0)) {
+                            "mlterm-status-window", NULL, 0)) {
 #ifdef DEBUG
     bl_warn_printf(BL_DEBUG_TAG " ui_display_show_root() failed.\n");
 #endif

--- a/uitoolkit/ui_main_config.c
+++ b/uitoolkit/ui_main_config.c
@@ -129,6 +129,7 @@ void ui_prepare_for_main_config(bl_conf_t *conf) {
   bl_conf_add_opt(conf, 'M', "im", 0, "input_method",
                   "input method (xim/kbd/uim/m17nlib/scim/ibus/fcitx/canna/wnn/skk/iiimf/none) [xim]");
   bl_conf_add_opt(conf, 'N', "name", 0, "app_name", "application name");
+  bl_conf_add_opt(conf, '\0', "role", 0, "wm_role", "application role [none]");
   bl_conf_add_opt(conf, 'O', "sbmod", 0, "scrollbar_mode",
                   "scrollbar mode (none/left/right/autohide) [none]");
   bl_conf_add_opt(conf, 'P', "clip", 1, "use_clipboard",
@@ -391,6 +392,9 @@ void ui_main_config_init(ui_main_config_t *main_config, bl_conf_t *conf, int arg
 #ifdef USE_XLIB
   if ((value = bl_conf_get_value(conf, "icon_name"))) {
     main_config->icon_name = strdup(value);
+  }
+  if ((value = bl_conf_get_value(conf, "wm_role"))) {
+    main_config->wm_role = strdup(value);
   }
 #endif
 
@@ -1471,6 +1475,7 @@ void ui_main_config_final(ui_main_config_t *main_config) {
   free(main_config->app_name);
   free(main_config->title);
   free(main_config->icon_name);
+  free(main_config->wm_role);
   free(main_config->term_type);
   free(main_config->scrollbar_view_name);
   free(main_config->pic_file_path);

--- a/uitoolkit/ui_main_config.h
+++ b/uitoolkit/ui_main_config.h
@@ -41,6 +41,7 @@ typedef struct ui_main_config {
   char *app_name;
   char *title;
   char *icon_name;
+  char *wm_role;
   char *term_type;
   char *scrollbar_view_name;
   char *pic_file_path;

--- a/uitoolkit/ui_screen_manager.c
+++ b/uitoolkit/ui_screen_manager.c
@@ -637,7 +637,7 @@ static ui_screen_t *open_screen_intern(char *disp_name, vt_term_t *term, ui_layo
     }
 
     if (!ui_display_show_root(disp, root, main_config.x, main_config.y, main_config.geom_hint,
-                              main_config.app_name, main_config.parent_window)) {
+                              main_config.app_name, main_config.wm_role, main_config.parent_window)) {
 #ifdef DEBUG
       bl_warn_printf(BL_DEBUG_TAG " ui_display_show_root() failed.\n");
 #endif

--- a/uitoolkit/ui_window.h
+++ b/uitoolkit/ui_window.h
@@ -163,6 +163,7 @@ typedef struct ui_window {
  */
 
 #ifdef USE_XLIB
+  char *wm_role;
   int8_t wall_picture_is_set;     /* Actually set picture (including transparency)
                                      or not. */
   int8_t wait_copy_area_response; /* Used for XCopyArea() */

--- a/uitoolkit/wayland/ui_display.c
+++ b/uitoolkit/wayland/ui_display.c
@@ -2624,7 +2624,7 @@ ui_display_t **ui_get_opened_displays(u_int *num) {
 int ui_display_fd(ui_display_t *disp) { return wl_display_get_fd(disp->display->wlserv->display); }
 
 int ui_display_show_root(ui_display_t *disp, ui_window_t *root, int x, int y, int hint,
-                         char *app_name, Window parent_window) {
+                         char *app_name, char *wm_role, Window parent_window) {
   void *p;
 
   if (parent_window) {

--- a/uitoolkit/win32/ui_display.c
+++ b/uitoolkit/win32/ui_display.c
@@ -257,7 +257,7 @@ ui_display_t **ui_get_opened_displays(u_int *num) {
 int ui_display_fd(ui_display_t *disp) { return disp->display->fd; }
 
 int ui_display_show_root(ui_display_t *disp, ui_window_t *root, int x, int y, int hint,
-                         char *app_name, Window parent_window /* Ignored */
+                         char *app_name, char *wm_role, Window parent_window /* Ignored */
                          ) {
   void *p;
 

--- a/uitoolkit/xlib/ui_display.c
+++ b/uitoolkit/xlib/ui_display.c
@@ -339,7 +339,7 @@ ui_display_t **ui_get_opened_displays(u_int *num) {
 int ui_display_fd(ui_display_t *disp) { return XConnectionNumber(disp->display); }
 
 int ui_display_show_root(ui_display_t *disp, ui_window_t *root, int x, int y, int hint,
-                         char *app_name, Window parent_window) {
+                         char *app_name, char *wm_role, Window parent_window) {
   void *p;
 
   if ((p = realloc(disp->roots, sizeof(ui_window_t *) * (disp->num_roots + 1))) == NULL) {
@@ -368,6 +368,11 @@ int ui_display_show_root(ui_display_t *disp, ui_window_t *root, int x, int y, in
   if (app_name) {
     root->app_name = app_name;
   }
+#ifdef USE_XLIB
+  if (wm_role) {
+    root->wm_role = wm_role;
+  }
+#endif
 
   /*
    * root is added to disp->roots before ui_window_show() because

--- a/uitoolkit/xlib/ui_window.c
+++ b/uitoolkit/xlib/ui_window.c
@@ -52,6 +52,7 @@
 #define XA_XROOTPMAP_ID(display) (XInternAtom(display, "_XROOTPMAP_ID", False))
 #define XA_XSETROOT_ID(display) (XInternAtom(display, "_XSETROOT_ID", False))
 #define XA_WM_CLIENT_LEADER(display) (XInternAtom(display, "WM_CLIENT_LEADER", False))
+#define XA_WM_WINDOW_ROLE(display) (XInternAtom(display, "WM_WINDOW_ROLE", False))
 
 /*
  * Extended Window Manager Hint support
@@ -1458,6 +1459,13 @@ int ui_window_show(ui_window_t *win, int hint) {
     XChangeProperty(win->disp->display, win->my_window,
                     XA_NET_WM_PID(win->disp->display), XA_CARDINAL,
                     32, PropModeReplace, (unsigned char *)&pid, 1);
+
+    if (win->wm_role && *win->wm_role) {
+      XChangeProperty(win->disp->display, win->my_window,
+                      XA_WM_WINDOW_ROLE(win->disp->display), XA_STRING,
+                      8, PropModeReplace, (unsigned char *)win->wm_role,
+                      (int)strlen(win->wm_role));
+    }
   }
 
   if (win->parent && !win->parent->is_transparent && win->parent->wall_picture_is_set) {


### PR DESCRIPTION
This proposes to add support for a --role option to mlterm to define the WM_WINDOW_ROLE property which is defined in the ICCCM standard in section 5.1. Other terminals like roxterm, gnome-terminal, mate-terminal, and xfce4-terminal support this option too. The --role is used to uniquely identify a window among several windows of that same application. It can be used in session management or to select role specific resources.