### PR TITLE
Fix buffer overflow with long plugin suffix

### DIFF
--- a/uitoolkit/ui_im.c
+++ b/uitoolkit/ui_im.c
@@ -77,7 +77,7 @@ static int dlsym_im_new_func(char *im_name, ui_im_new_func_t *func, bl_dl_handle
   sprintf(symname, "im_%s_new", im_name);
 
 #ifdef PLUGIN_MODULE_SUFFIX
-  if ((im_name2 = alloca(strlen(im_name) + 3 + 1))) {
+  if ((im_name2 = alloca(strlen(im_name) + strlen(PLUGIN_MODULE_SUFFIX) + 2))) {
     sprintf(im_name2, "%s-" PLUGIN_MODULE_SUFFIX, im_name);
 
     if (!(*handle = im_dlopen(im_name2))) {

--- a/uitoolkit/ui_sb_view_factory.c
+++ b/uitoolkit/ui_sb_view_factory.c
@@ -48,7 +48,7 @@ static ui_sb_view_new_func_t dlsym_sb_view_new_func(const char *name, int is_tra
 #ifdef PLUGIN_MODULE_SUFFIX
   char *p;
 
-  if (!(p = alloca(strlen(name) + 3 + 1))) {
+  if (!(p = alloca(strlen(name) + strlen(PLUGIN_MODULE_SUFFIX) + 2))) {
     return NULL;
   }
 
@@ -98,7 +98,7 @@ static ui_sb_engine_new_func_t dlsym_sb_engine_new_func(const char *name) {
 #ifdef PLUGIN_MODULE_SUFFIX
   char *p;
 
-  if (!(p = alloca(strlen(name) + 3 + 1))) {
+  if (!(p = alloca(strlen(name) + strlen(PLUGIN_MODULE_SUFFIX) + 2))) {
     return NULL;
   }
 


### PR DESCRIPTION
The buffer length for appending suffix to module name is not correctly calculated. Fix the calculation to avoid memory corruption.