### PR TITLE
Add new use_locked_title (bool) option (default==false) to lock mlterm window title

### DIFF
--- a/man/mlterm.1
+++ b/man/mlterm.1
@@ -231,6 +231,11 @@ built-in simple scrollbar.
 Specify a title for a mlterm window.
 The default is "\fBmlterm\fR".
 .TP
+\fB\-\-locktitle\fR(=\fIbool\fR)
+Lock the title for a mlterm window.  If a title is locked then
+OSC 0/2 esc sequences to change it are ignored.
+The default is \fBfalse\fR.
+.TP
 \fB\-U\fR, \fB\-\-viaucs\fR(=\fIbool\fR)
 Force to convert a selection (i.e., copy-and-paste strings) whose
 type is not UTF8_STRING to the current mlterm encoding via Unicode.

--- a/uitoolkit/ui_main_config.c
+++ b/uitoolkit/ui_main_config.c
@@ -138,6 +138,7 @@ void ui_prepare_for_main_config(bl_conf_t *conf) {
   bl_conf_add_opt(conf, 'S', "sbview", 0, "scrollbar_view_name",
                   "scrollbar view name (simple/sample/...) [simple]");
   bl_conf_add_opt(conf, 'T', "title", 0, "title", "title name");
+  bl_conf_add_opt(conf, '\0', "locktitle", 1, "use_locked_title", "use locked title [false]");
   bl_conf_add_opt(conf, 'U', "viaucs", 1, "receive_string_via_ucs",
                   "process received (pasted) strings via Unicode [false]");
   bl_conf_add_opt(conf, 'V', "varwidth", 1, "use_variable_column_width",
@@ -401,6 +402,14 @@ void ui_main_config_init(ui_main_config_t *main_config, bl_conf_t *conf, int arg
 
   if ((value = bl_conf_get_value(conf, "title"))) {
     main_config->title = strdup(value);
+  }
+
+  if ((value = bl_conf_get_value(conf, "use_locked_title"))) {
+    if (strcmp(value, "true") == 0) {
+      main_config->use_locked_title = 1;
+    }
+  } else {
+    main_config->use_locked_title = 0;
   }
 
 #ifdef USE_XLIB

--- a/uitoolkit/ui_main_config.h
+++ b/uitoolkit/ui_main_config.h
@@ -110,6 +110,7 @@ typedef struct ui_main_config {
   int8_t use_bold_font;
   int8_t use_italic_font;
   int8_t use_local_echo;
+  int8_t use_locked_title;
   int8_t use_x11_forwarding;
   int8_t use_auto_detect;
   int8_t unlimit_log_size;

--- a/uitoolkit/ui_screen_manager.c
+++ b/uitoolkit/ui_screen_manager.c
@@ -121,7 +121,7 @@ static vt_term_t *create_term_intern(void) {
            main_config.vertical_mode, main_config.use_local_echo, main_config.title,
            main_config.icon_name, main_config.use_ansi_colors, main_config.alt_color_mode,
            main_config.use_ot_layout, main_config.blink_cursor ? CS_BLINK|CS_BLOCK : CS_BLOCK,
-           main_config.ignore_broadcasted_chars)) == NULL) {
+           main_config.ignore_broadcasted_chars, main_config.use_locked_title)) == NULL) {
     return NULL;
   }
 

--- a/vtemu/mlterm.c
+++ b/vtemu/mlterm.c
@@ -60,6 +60,7 @@ vt_term_t *mlterm_open(char *host, char *pass, int cols, int rows, u_int log_siz
   static int use_login_shell;
   static int logging_vt_seq;
   static int use_local_echo;
+  static int use_locked_title;
   static int use_auto_detect;
   static int use_ansi_colors;
   static char *term_type;
@@ -119,6 +120,7 @@ vt_term_t *mlterm_open(char *host, char *pass, int cols, int rows, u_int log_siz
 #ifdef USE_LOCAL_ECHO_BY_DEFAULT
     use_local_echo = 1;
 #endif
+    use_locked_title = 0;
     use_ansi_colors = 1;
 
     if ((conf = bl_conf_new())) {
@@ -213,6 +215,12 @@ vt_term_t *mlterm_open(char *host, char *pass, int cols, int rows, u_int log_siz
           use_local_echo = 1;
         }
 #endif
+      }
+
+      if ((value = bl_conf_get_value(conf, "use_locked_title"))) {
+        if (strcmp(value, "true") == 0) {
+            use_locked_title = 1;
+        }
       }
 
       if ((value = bl_conf_get_value(conf, "use_alt_buffer"))) {
@@ -328,7 +336,8 @@ vt_term_t *mlterm_open(char *host, char *pass, int cols, int rows, u_int log_siz
                               0 /* use_dynamic_comb */, BSM_STATIC, 0 /* vertical_mode */,
                               use_local_echo, NULL, NULL, use_ansi_colors, 0 /* alt_color_mode */,
                               0 /* use_ot_layout */, 0 /* cursor_style */,
-                              0 /* ignore_broadcasted_chars */))) {
+                              0 /* ignore_broadcasted_chars */,
+                              use_locked_title))) {
     goto error;
   }
 

--- a/vtemu/vt_parser.c
+++ b/vtemu/vt_parser.c
@@ -1556,6 +1556,12 @@ end:
 static void set_window_name(vt_parser_t *vt_parser,
                             u_char *name /* should be malloc'ed or NULL. */
                             ) {
+  if (vt_parser->use_locked_title) {
+    if (name)
+      free(name);
+    return;
+  }
+
   free(vt_parser->win_name);
   vt_parser->win_name = name;
 
@@ -7100,7 +7106,7 @@ vt_parser_t *vt_parser_new(vt_screen_t *screen, vt_termcap_ptr_t termcap, vt_cha
                            vt_unicode_policy_t policy, u_int col_size_a, int use_char_combining,
                            int use_multi_col_char, const char *win_name, const char *icon_name,
                            int use_ansi_colors, vt_alt_color_mode_t alt_color_mode,
-                           vt_cursor_style_t cursor_style, int ignore_broadcasted_chars, int use_local_echo) {
+                           vt_cursor_style_t cursor_style, int ignore_broadcasted_chars, int use_local_echo, int use_locked_title) {
   vt_parser_t *vt_parser;
 
   if ((vt_parser = calloc(1, sizeof(vt_parser_t))) == NULL) {
@@ -7163,6 +7169,7 @@ vt_parser_t *vt_parser_new(vt_screen_t *screen, vt_termcap_ptr_t termcap, vt_cha
   vt_parser->saved_vtmode_flags[1] = vt_parser->vtmode_flags[1] = INITIAL_VTMODE_FLAGS_1;
   vt_parser->ignore_broadcasted_chars = ignore_broadcasted_chars;
   vt_parser->use_local_echo = use_local_echo;
+  vt_parser->use_locked_title = use_locked_title;
 
   return vt_parser;
 

--- a/vtemu/vt_parser.h
+++ b/vtemu/vt_parser.h
@@ -315,6 +315,7 @@ typedef struct vt_parser {
   int is_transferring_data : 2; /* 0x1=send 0x2=recv */
   int is_zmodem_ready : 1;
   int use_local_echo : 1;
+  int use_locked_title : 1;
 
 #ifdef USE_VT52
   int is_vt52_mode : 1;
@@ -359,7 +360,7 @@ vt_parser_t *vt_parser_new(vt_screen_t *screen, vt_termcap_ptr_t termcap, vt_cha
                            vt_unicode_policy_t policy, u_int col_size_a, int use_char_combining,
                            int use_multi_col_char, const char *win_name, const char *icon_name,
                            int use_ansi_colors, vt_alt_color_mode_t alt_color_mode,
-                           vt_cursor_style_t cursor_style, int ignore_broadcasted_chars, int use_local_echo);
+                           vt_cursor_style_t cursor_style, int ignore_broadcasted_chars, int use_local_echo, int use_locked_title);
 
 int vt_parser_destroy(vt_parser_t *vt_parser);
 

--- a/vtemu/vt_term.c
+++ b/vtemu/vt_term.c
@@ -229,7 +229,7 @@ vt_term_t *vt_term_new(const char *term_type, u_int cols, u_int rows, u_int tab_
                        int use_dynamic_comb, vt_bs_mode_t bs_mode, vt_vertical_mode_t vertical_mode,
                        int use_local_echo, const char *win_name, const char *icon_name,
                        int use_ansi_colors, vt_alt_color_mode_t alt_color_mode, int use_ot_layout,
-                       vt_cursor_style_t cursor_style, int ignore_broadcasted_chars) {
+                       vt_cursor_style_t cursor_style, int ignore_broadcasted_chars, int use_locked_title) {
   vt_termcap_ptr_t termcap;
   vt_term_t *term;
 
@@ -269,7 +269,7 @@ vt_term_t *vt_term_new(const char *term_type, u_int cols, u_int rows, u_int tab_
                                      use_auto_detect, logging_vt_seq, policy, col_size_a,
                                      use_char_combining, use_multi_col_char, win_name, icon_name,
                                      use_ansi_colors, alt_color_mode, cursor_style,
-                                     ignore_broadcasted_chars, use_local_echo))) {
+                                     ignore_broadcasted_chars, use_local_echo, use_locked_title))) {
 #ifdef DEBUG
     bl_warn_printf(BL_DEBUG_TAG " vt_parser_new failed.\n");
 #endif

--- a/vtemu/vt_term.h
+++ b/vtemu/vt_term.h
@@ -69,7 +69,7 @@ vt_term_t *vt_term_new(const char *term_type, u_int cols, u_int rows, u_int tab_
                        int use_dynamic_comb, vt_bs_mode_t bs_mode, vt_vertical_mode_t vertical_mode,
                        int use_local_echo, const char *win_name, const char *icon_name,
                        int use_ansi_colors, vt_alt_color_mode_t alt_color_mode, int use_ot_layout,
-                       vt_cursor_style_t cursor_style, int ignore_broadcasted_chars);
+                       vt_cursor_style_t cursor_style, int ignore_broadcasted_chars, int use_locked_title);
 
 void vt_term_destroy(vt_term_t *term);
 

--- a/vtemu/vt_term_manager.c
+++ b/vtemu/vt_term_manager.c
@@ -269,7 +269,7 @@ vt_term_t *vt_create_term(const char *term_type, u_int cols, u_int rows, u_int t
                           const char *win_name, const char *icon_name,
                           int use_ansi_colors, vt_alt_color_mode_t alt_color_mode,
                           int use_ot_layout, vt_cursor_style_t cursor_style,
-                          int ignore_broadcasted_chars) {
+                          int ignore_broadcasted_chars, int use_locked_title) {
 #if !defined(USE_WIN32API) && !defined(DEBUG)
   char *list;
   char *list_tmp;
@@ -300,7 +300,7 @@ vt_term_t *vt_create_term(const char *term_type, u_int cols, u_int rows, u_int t
                    use_auto_detect, logging_vt_seq, policy, col_size_a, use_char_combining,
                    use_multi_col_char, use_ctl, bidi_mode, bidi_separators, use_dynamic_comb,
                    bs_mode, vertical_mode, use_local_echo, win_name, icon_name, use_ansi_colors,
-                   alt_color_mode, use_ot_layout, cursor_style, ignore_broadcasted_chars))) {
+                   alt_color_mode, use_ot_layout, cursor_style, ignore_broadcasted_chars, use_locked_title))) {
             vt_term_plug_pty(terms[num_terms++], pty);
             vt_set_pty_winsize(pty, cols, rows, 0, 0);
 
@@ -341,7 +341,7 @@ vt_term_t *vt_create_term(const char *term_type, u_int cols, u_int rows, u_int t
                                           use_multi_col_char, use_ctl, bidi_mode, bidi_separators,
                                           use_dynamic_comb, bs_mode, vertical_mode, use_local_echo,
                                           win_name, icon_name, use_ansi_colors, alt_color_mode,
-                                          use_ot_layout, cursor_style, ignore_broadcasted_chars))) {
+                                          use_ot_layout, cursor_style, ignore_broadcasted_chars, use_locked_title))) {
     return NULL;
   }
 

--- a/vtemu/vt_term_manager.h
+++ b/vtemu/vt_term_manager.h
@@ -21,7 +21,7 @@ vt_term_t *vt_create_term(const char *term_type, u_int cols, u_int rows, u_int t
                           const char *win_name, const char *icon_name,
                           int use_ansi_colors, vt_alt_color_mode_t alt_color_mode,
                           int use_ot_layout, vt_cursor_style_t cursor_style,
-                          int ignore_broadcasted_chars);
+                          int ignore_broadcasted_chars, int use_locked_title);
 
 void vt_destroy_term(vt_term_t *term);
 


### PR DESCRIPTION
Hi,

Thank you for mlterm.
One feature I'm used to in other terminals is the ability to set the window title and then don't allow an OSC seq to change it.
Here is a hack attempt PR at that, where if the title is specified then it is locked.
Another way would be a specific, separate lock_title option.
What do you think ?

thx,
-m