### PR TITLE
* tool/mlconfig/Makefile.in: @X_LIBS@ should be used to link -lX11.

### DIFF
--- a/tool/mlconfig/Makefile.in
+++ b/tool/mlconfig/Makefile.in
@@ -33,7 +33,7 @@ CFLAGS = $(CFLAGS_LOCAL) @GTK_CFLAGS_FOR_MLCONFIG@ @IMAGELIB_CFLAGS@ @DEB_CFLAGS
 LIBS1 = $(LIBS_LOCAL) @INTL_LIBS@ @DL_SELF@ @DL_LIBS_IM@ @GTK_LIBS_FOR_MLCONFIG@
 
 # -lX11 is for http://fedoraproject.org/wiki/Features/ChangeInImplicitDSOLinking
-LIBS2_xlib = $(LPOBL) -lX11 -L/usr/local/lib -R/usr/local/lib
+LIBS2_xlib = $(LPOBL) @X_LIBS@
 
 LIBS2_wayland = $(LPOBL)
 


### PR DESCRIPTION
This fixes a github workflow CI test for NetBSD:
https://github.com/tsutsui/mlterm/actions/runs/8394742659/job/22992531392#step:3:8619
```
  ../../libtool --mode=link gcc main.o mc_combo.o mc_char_encoding.o mc_im.o mc_tabsize.o mc_logsize.o  mc_font.o mc_color.o mc_radio.o mc_space.o mc_alpha.o mc_ctl.o  mc_sb_view.o mc_wall_pic.o mc_bgtype.o mc_io.o mc_io_pty.o mc_io_file.o  mc_pty.o mc_char_width.o mc_flags.o mc_auto_detect.o mc_ratio.o mc_wordsep.o  mc_unicode_areas.o mc_geometry.o mc_click.o mc_opentype.o  -I/usr/pkg/include/gtk-3.0 -I/usr/pkg/include/pango-1.0 -I/usr/pkg/include/cairo -I/usr/pkg/include/gdk-pixbuf-2.0 -I/usr/X11R7/include -I/usr/pkg/include -I/usr/X11R7/include/freetype2 -I/usr/pkg/include/harfbuzz -I/usr/pkg/include/dbus-1.0 -I/usr/pkg/lib/dbus-1.0/include -I/usr/pkg/include/glib-2.0 -I/usr/pkg/lib/glib-2.0/include -I/usr/pkg/include/atk-1.0 -pthread -I/usr/pkg/include/libpng16 -I/usr/X11R7/include/pixman-1 -D_REENTRANT -I/usr/pkg/include/gio-unix-2.0 -I/usr/pkg/include/fribidi -I/usr/pkg/include/at-spi2-atk/2.0 -I/usr/pkg/include/at-spi-2.0    -I../../baselib/include   -Wall -g -O2   -I../../xwindow -I../../vtemu  -I../../common -I../../common  -I../../inputmethod  -I/usr/local/include  -DSYSCONFDIR=\"/usr/local/etc\" -DLOCALEDIR=\"/usr/local/share/locale\"  -DXDATADIR=\"/usr/local/share\" -DLIBDIR=\"/usr/local/lib\" -o mlconfig  -lintl   -L/usr/pkg/lib -lgtk-3 -lgdk-3 -lharfbuzz -lpangocairo-1.0 -lpango-1.0 -latk-1.0 -lcairo -lcairo-gobject -lgdk_pixbuf-2.0 -lgio-2.0 -lglib-2.0 -lintl -Wl,-R/usr/pkg/lib -lgobject-2.0 ../../baselib/src/libpobl.la -lX11 -L/usr/local/lib -R/usr/local/lib
  libtool: link: gcc main.o mc_combo.o mc_char_encoding.o mc_im.o mc_tabsize.o mc_logsize.o mc_font.o mc_color.o mc_radio.o mc_space.o mc_alpha.o mc_ctl.o mc_sb_view.o mc_wall_pic.o mc_bgtype.o mc_io.o mc_io_pty.o mc_io_file.o mc_pty.o mc_char_width.o mc_flags.o mc_auto_detect.o mc_ratio.o mc_wordsep.o mc_unicode_areas.o mc_geometry.o mc_click.o mc_opentype.o -I/usr/pkg/include/gtk-3.0 -I/usr/pkg/include/pango-1.0 -I/usr/pkg/include/cairo -I/usr/pkg/include/gdk-pixbuf-2.0 -I/usr/X11R7/include -I/usr/pkg/include -I/usr/X11R7/include/freetype2 -I/usr/pkg/include/harfbuzz -I/usr/pkg/include/dbus-1.0 -I/usr/pkg/lib/dbus-1.0/include -I/usr/pkg/include/glib-2.0 -I/usr/pkg/lib/glib-2.0/include -I/usr/pkg/include/atk-1.0 -I/usr/pkg/include/libpng16 -I/usr/X11R7/include/pixman-1 -D_REENTRANT -I/usr/pkg/include/gio-unix-2.0 -I/usr/pkg/include/fribidi -I/usr/pkg/include/at-spi2-atk/2.0 -I/usr/pkg/include/at-spi-2.0 -I../../baselib/include -Wall -g -O2 -I../../xwindow -I../../vtemu -I../../common -I../../common -I../../inputmethod -I/usr/local/include -DSYSCONFDIR=\"/usr/local/etc\" -DLOCALEDIR=\"/usr/local/share/locale\" -DXDATADIR=\"/usr/local/share\" -DLIBDIR=\"/usr/local/lib\" -o .libs/mlconfig -Wl,-R/usr/pkg/lib  -L/usr/pkg/lib -lgtk-3 -lgdk-3 -lharfbuzz -lpangocairo-1.0 -lpango-1.0 -latk-1.0 -lcairo -lcairo-gobject -lgdk_pixbuf-2.0 -lgio-2.0 -lglib-2.0 /usr/pkg/lib/libintl.so -lgobject-2.0 ../../baselib/src/.libs/libpobl.so -lX11 -L/usr/local/lib -pthread -Wl,-rpath -Wl,/usr/pkg/lib -Wl,-rpath -Wl,/usr/local/lib
  ld: cannot find -lX11
  *** Error code 1
  
  Stop.
  make[1]: stopped in /home/runner/work/mlterm/mlterm/tool/mlconfig
  *** Error code 1
  
  Stop.
```