### PR TITLE
Fix CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,29 +14,42 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: "setup linux build environment"
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
-      run: sudo apt update; sudo apt install -y libgtk-3-dev libvterm-dev libvte-2.91-dev libsdl2-dev libfribidi-dev libuim-dev libfcitx5core-dev libfcitx5gclient-dev libscim-dev libssh2-1-dev curl
+    - name: setup build environment
+      run: |
+        case "${{ matrix.os }}" in
+        ubuntu*)
+          sudo apt update; sudo apt install -y libgtk-3-dev libvterm-dev libvte-2.91-dev libsdl2-dev libfribidi-dev libuim-dev libfcitx5core-dev libfcitx5gclient-dev libscim-dev libssh2-1-dev curl
+          ;;
+        macos*)
+          brew install pkg-config
+          ;;
+        esac
 
-    - name: "setup macos build environment"
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      run: brew install pkg-config
+    - name: configure
+      run: |
+        case "${{ matrix.os }}" in
+        ubuntu*)
+          (cd uitoolkit/wayland && sh ./rescanproto.sh)
+          CONFIGURE_ARGS="--with-gui=xlib,fb,console,wayland,sdl2"
+          ;;
+        macos*)
+          CONFIGURE_ARGS="--with-gui=quartz"
+          ;;
+        esac
+        CFLAGS="-Wall -g -O2" ./configure ${CONFIGURE_ARGS}
 
-    - name: "configure on linux"
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
-      run: (cd uitoolkit/wayland; sh ./rescanproto.sh); CFLAGS="-Wall -g -O2" ./configure --with-gui=xlib,fb,console,wayland,sdl2
-
-    - name: "configure on macos"
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      run: CFLAGS="-Wall -g -O2" ./configure --with-gui=quartz
-
-    - name: "build on linux"
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
-      run: make; sudo make install; (cd gtk; make; sudo make install); (cd libvterm; make; sudo make install)
-
-    - name: "build on macos"
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      run: make; sudo make install
+    - name: build
+      run: |
+        make
+        sudo make install
+        case "${{ matrix.os }}" in
+        ubuntu*)
+          (cd gtk && make && sudo make install)
+          (cd libvterm && make && sudo make install)
+          ;;
+        macos*)
+          ;;
+        esac
 
   build-netbsd:
     name: "build-netbsd (NetBSD/amd64 10.0 with pkgsrc)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
 


### PR DESCRIPTION
* `fail-fast: false` seems necessary to avoid abort on errors on other OSes
* `case "${{ matrix.os }}"` in shell to switch OSes is more maintainable