### PR TITLE
* wayland/ui_display.c: Fix implicit function decl.

### DIFF
--- a/uitoolkit/wayland/ui_display.c
+++ b/uitoolkit/wayland/ui_display.c
@@ -18,6 +18,7 @@
 #include "../ui_window.h"
 #include "../ui_picture.h"
 #include "../ui_imagelib.h"
+#include "../ui_event_source.h"
 
 #if 0
 #define __DEBUG


### PR DESCRIPTION
Fixes the following warning:
```
../uitoolkit/wayland/ui_display.c: In function 'ui_display_open':
../uitoolkit/wayland/ui_display.c:2748:5: warning: implicit declaration of function 'ui_event_source_add_fd' [-Wimplicit-function-declaration]
 2748 |     ui_event_source_add_fd(-10, auto_repeat);
      |     ^~~~~~~~~~~~~~~~~~~~~~
```

Note this "implicit function declaration" warning is treated as a fatal error on archLinux with gcc14.