### PR TITLE
* ci.yml: archLinux also requires fcitx5-gtk for Fcitx5GClient.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           apt install -y build-essential flex libgtk-3-dev libvterm-dev libvte-2.91-dev libsdl2-dev libfribidi-dev libuim-dev libfcitx5core-dev libfcitx5gclient-dev libscim-dev libibus-1.0-dev libm17n-dev libwnn-dev libcanna1g-dev libssh2-1-dev curl
           ;;
         archlinux*)
-          pacman -Syyu --noconfirm base-devel intltool libutempter wayland gtk3 libvterm vte3 sdl2 fribidi fcitx5 scim ibus m17n-lib libssh2 curl
+          pacman -Syyu --noconfirm base-devel intltool libutempter wayland gtk3 libvterm vte3 sdl2 fribidi fcitx5 fcitx5-gtk scim ibus m17n-lib libssh2 curl
           ;;
         esac
 


### PR DESCRIPTION
This should have been in https://github.com/arakiken/mlterm/commit/65787afaf1427f364fd3e14087188b9fe5c1ad02 and now configure probes fcitx5 properly:
```
Mlterm was configured as follows

Installation path prefix          : /usr/local
Build shared libraries            : yes
Build static libraries            : yes
GUI toolkit                       : xlib
BiDi rendering (Fribidi)          : yes
Indic rendering                   : yes
OpenType Layout                   : yes (harfbuzz)
External tools                    : mlclient mlconfig mlcc mlterm-menu mlimgloader registobmp mlfc
Image processing                  : yes
Built-in image library            : 
utmp support                      : 
Type engines                      : xcore xft cairo
DnD                               : yes
Input Methods                     : XIM kbd m17nlib iBus fcitx5 SCIM skk
Scrollbars                        : simple sample extra pixmap_engine
libssh2                           : yes
mosh directory                    : 
GTK+                              : yes (3.0)
libvte                            : yes (2.91)
brlapi                            : no
VT52                              : no
Permission of mlterm binary       : -m 755
Compact true color                : yes
```