### PR TITLE
Fix ci netbsd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
             export PATH
             ftp -o - https://cdn.NetBSD.org/pub/NetBSD/NetBSD-`uname -r`/amd64/binary/sets/xbase.tar.xz | tar -C / -zxpf - ./usr/X11R7/bin ./usr/X11R7/include ./usr/X11R7/lib ./usr/X11R7/share
             ftp -o - https://cdn.NetBSD.org/pub/NetBSD/NetBSD-`uname -r`/amd64/binary/sets/xcomp.tar.xz | tar -C / -zxpf - ./usr/X11R7/bin ./usr/X11R7/include ./usr/X11R7/lib ./usr/X11R7/share
+            # Explicitly update glib2 first. It has been pre-installed by
+            # vmactions/netbsd-builder for fuse-sshfs
+            pkg_add -u glib2
             pkg_add -u pkgconf gettext-tools libtool-base
             pkg_add -u cairo Canna-lib fribidi gdk-pixbuf2 gtk3+ fcitx ibus m17n-lib harfbuzz scim uim ja-FreeWnn-lib libXft SDL2 libssh2 vte3
           run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,8 @@ jobs:
         uses: vmactions/netbsd-vm@v1
         with:
           release: "10.0"
-          usesh: true
           copyback: false
           prepare: |
-            PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R7/bin:/usr/pkg/bin:/usr/pkg/sbin:/usr/games:/usr/local/bin:/usr/local/sbin
-            export PATH
             ftp -o - https://cdn.NetBSD.org/pub/NetBSD/NetBSD-`uname -r`/amd64/binary/sets/xbase.tar.xz | tar -C / -zxpf - ./usr/X11R7/bin ./usr/X11R7/include ./usr/X11R7/lib ./usr/X11R7/share
             ftp -o - https://cdn.NetBSD.org/pub/NetBSD/NetBSD-`uname -r`/amd64/binary/sets/xcomp.tar.xz | tar -C / -zxpf - ./usr/X11R7/bin ./usr/X11R7/include ./usr/X11R7/lib ./usr/X11R7/share
             # Explicitly update glib2 first. It has been pre-installed by
@@ -87,8 +84,6 @@ jobs:
             pkg_add -u pkgconf gettext-tools libtool-base
             pkg_add -u cairo Canna-lib fribidi gdk-pixbuf2 gtk3+ fcitx ibus m17n-lib harfbuzz scim uim ja-FreeWnn-lib libXft SDL2 libssh2 vte3
           run: |
-            PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R7/bin:/usr/pkg/bin:/usr/pkg/sbin:/usr/games:/usr/local/bin:/usr/local/sbin
-            export PATH
             CFLAGS="-Wall -Werror=incompatible-pointer-types -g -O2" CPPFLAGS="-I/usr/pkg/include" ./configure --x-includes=/usr/X11R7/include --x-libraries=/usr/X11R7/lib --with-imagelib=gdk-pixbuf --with-gui=xlib,wscons,sdl2 --with-type-engins=xcore,xft,cairo --enable-anti-alias
             make
             make install


### PR DESCRIPTION
Two changes for NetBSD CI:
* netbsd-vm installed glib2 from pkgsrc (maybe 2024Q2) but sometimes pkgsrc doesn't handle its dependencies properly and could cause warnings on updating gdk_pixbuf2 etc.:
```
g_module_open() failed for /usr/pkg/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-ani.so: /usr/pkg/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-ani.so: Undefined PLT symbol "g_once_init_enter_pointer" (symnum = 27)
  g_module_open() failed for /usr/pkg/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-bmp.so: /usr/pkg/lib/libgdk_pixbuf-2.0.so.0: Undefined PLT symbol "g_once_init_enter_pointer" (symnum = 268)
  g_module_open() failed for /usr/pkg/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-gif.so: /usr/pkg/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-gif.so: Undefined PLT symbol "g_once_init_enter_pointer" (symnum = 41)
  g_module_open() failed for /usr/pkg/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-icns.so: /usr/pkg/lib/libgdk_pixbuf-2.0.so.0: Undefined PLT symbol "g_once_init_enter_pointer" (symnum = 268)
  g_module_open() failed for /usr/pkg/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-ico.so: /usr/pkg/lib/libgdk_pixbuf-2.0.so.0: Undefined PLT symbol "g_once_init_enter_pointer" (symnum = 268)
```
* It turns out `usesh: true` is not necessary because NetBSD's root shell is `/bin/sh` and using `execSSHSH()` invoked by `usesh: true` doesn't load `/root/.profile`:
https://github.com/vmactions/netbsd-vm/issues/10