### PR TITLE
fb: Fix build failure with 64-bit time_t using input_event macros

### DIFF
--- a/uitoolkit/fb/ui_display_linux.c
+++ b/uitoolkit/fb/ui_display_linux.c
@@ -682,7 +682,7 @@ static int receive_mouse_event(int fd) {
         continue;
       }
 
-      xev.time = ev.time.tv_sec * 1000 + ev.time.tv_usec / 1000;
+      xev.time = ev.input_event_sec * 1000 + ev.input_event_usec / 1000;
       if (rotate_display) {
         if (rotate_display > 0) {
           xev.x = _mouse.y;
@@ -769,7 +769,7 @@ static int receive_mouse_event(int fd) {
         xev.x = _mouse.x;
         xev.y = _mouse.y;
       }
-      xev.time = ev.time.tv_sec * 1000 + ev.time.tv_usec / 1000;
+      xev.time = ev.input_event_sec * 1000 + ev.input_event_usec / 1000;
       xev.state = _mouse.button_state | _display.key_state;
 
 #ifdef __DEBUG


### PR DESCRIPTION
Fix a compilation error in `gui/fb/uitoolkit/fb/ui_display_linux.c` on modern 32-bit systems with 64-bit time_t (e.g., time64 transition).

In these environments, the `time` field of `struct input_event` is no longer directly accessible due to Y2038 safety. This patch replaces direct access to `ev.time.tv_sec` and `ev.time.tv_usec` with the standard `ev.input_event_sec` and `ev.input_event_usec` compatibility macros.

These macros are safe for both 32-bit and 64-bit time_t and have existed since Linux v4.16: https://github.com/torvalds/linux/blob/v4.16/include/uapi/linux/input.h#L28-L42