### PR TITLE
Fix buffer overflow in get_dpi(): alloca(strlen(p)) -> alloca(strlen(p) + 1)

### DIFF
--- a/uitoolkit/libtype/ui_font_ft.c
+++ b/uitoolkit/libtype/ui_font_ft.c
@@ -1281,7 +1281,7 @@ static double get_dpi(ui_font_t *font) {
   const char *p = XResourceManagerString(font->display);
   char *rs;
 
-  if ((rs = alloca(strlen(p))) != NULL) {
+  if ((rs = alloca(strlen(p) + 1)) != NULL) {
     strcpy(rs, p);
 
     while ((p = bl_str_sep(&rs, "\n")) != NULL) {


### PR DESCRIPTION
Fixes the buffer overflow crash introduced in 04fc42be (the Xft.dpi fix for #171).

`alloca(strlen(p))` does not account for the null terminator. `strcpy` writes one byte past the allocated buffer, causing `*** buffer overflow detected ***: terminated` on startup.

Reproduced on: Linux Mint 22.3, mlterm 3.9.5, Xft.dpi=307.

```diff
- alloca(strlen(p))
+ alloca(strlen(p) + 1)
```