### PR TITLE
* main/main_loop.c, man/mlterm.1, etc/main, etc/main.ja, doc/ja/README.ja: Fix hardcoded font size range default descriptions.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-08-14  sporteka <sporteka2@disroot.org>
+
+	* main/main_loop.c:
+	  Fix misleading "font size range for GUI configurator [1-100]"
+	  help description. The actual default range is 1-200 when
+	  USE_FREETYPE is enabled and 1-10000 otherwise.
+
 2026-08-14  Araki Ken <arakiken@user.sf.net>
 
 	* ui_im_candidate_screen.[ch]:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2026-08-14  sporteka <sporteka2@disroot.org>
 
+	* man/mlterm.1, etc/main, etc/main.ja, doc/ja/README.ja:
+	  Fix other hardcoded font size range default descriptions.
+	  The man page said the default is 1-10000 and the sample config
+	  files said 1-100, while the actual default range is 1-200 when
+	  USE_FREETYPE is enabled and 1-10000 otherwise.
+
+2026-08-14  sporteka <sporteka2@disroot.org>
+
 	* main/main_loop.c:
 	  Fix misleading "font size range for GUI configurator [1-100]"
 	  help description. The actual default range is 1-200 when

--- a/doc/ja/README.ja
+++ b/doc/ja/README.ja
@@ -642,7 +642,7 @@ comment -*- mode: text; tab-width:2; indent-tabs-mode:nil; coding:euc-jp -*-
         指定した場合には、fontsize オプションを変更しても、フォントサイズは(上記
         例では 14 pixel のまま)変わらなくなるため、注意してください。
 
-      o font_size_range  (*1-10000*)
+      o font_size_range  (*1-200*)
         変更可能なフォントサイズの範囲
 
         フォーマットは以下のとおり。

--- a/etc/main
+++ b/etc/main
@@ -63,7 +63,7 @@
 
 # fontsize = 16
 
-# font_size_range = 1-100
+# font_size_range = 1-200
 
 # hide_underline = false
 

--- a/etc/main.ja
+++ b/etc/main.ja
@@ -88,7 +88,7 @@
 # fontsize = 16
 
 # 変更可能なフォントサイズの範囲
-# font_size_range = 1-100
+# font_size_range = 1-200
 
 # アンダーラインを描画しない。
 # hide_underline = false

--- a/main/main_loop.c
+++ b/main/main_loop.c
@@ -220,7 +220,11 @@ int main_loop_init(int argc, char **argv) {
   bl_conf_add_opt(conf, 'h', "help", 1, "help", "show this help message");
   bl_conf_add_opt(conf, 'v', "version", 1, "version", "show version message");
   bl_conf_add_opt(conf, 'R', "fsrange", 0, "font_size_range",
-                  "font size range for GUI configurator [1-100]");
+#ifdef USE_FREETYPE
+                  "font size range for GUI configurator [1-200]");
+#else
+                  "font size range for GUI configurator [1-10000]");
+#endif
 #ifdef COMPOSE_DECSP_FONT
   bl_conf_add_opt(conf, 'Y', "decsp", 1, "compose_dec_special_font",
                   "compose dec special font [false]");

--- a/man/mlterm.1
+++ b/man/mlterm.1
@@ -221,7 +221,8 @@ The default is \fBtrue\fR.
 \fB\-R\fR, \fB\-\-fsrange\fR=\fIrange\fR
 Set acceptable range of font size.
 The format is "\fIminsize\fR-\fImaxsize\fR", where \fIminsize\fR and
-\fImaxsize\fR are font sizes in pixel (default \fB1-10000\fR).
+\fImaxsize\fR are font sizes in pixel (default \fB1-200\fR when freetype
+support is enabled, \fB1-10000\fR otherwise).
 The GUI configurator and other means for setting fontsize should honor
 the range.
 .TP


### PR DESCRIPTION
## Summary

The font size range default was hardcoded in several places with values that don't match the actual default. The actual default range is `1-200` when `USE_FREETYPE` is enabled and `1-10000` otherwise (see `uitoolkit/ui_font_manager.c`, lines 76-88).

## What was wrong

| Location | Before | After |
|---|---|---|
| `main/main_loop.c` help text (`-R`/`--fsrange`) | `[1-100]` | `[1-200]` (USE_FREETYPE) / `[1-10000]` (otherwise) |
| `man/mlterm.1` | `default 1-10000` | `default 1-200` (freetype) / `1-10000` (otherwise) |
| `etc/main`, `etc/main.ja` sample configs | `font_size_range = 1-100` | `font_size_range = 1-200` |
| `doc/ja/README.ja` | `(*1-10000*)` | `(*1-200*)` |

## Changes

- `main/main_loop.c`: Correct `font_size_range` help text via conditional compilation
- `man/mlterm.1`: Document both default ranges
- `etc/main`, `etc/main.ja`, `doc/ja/README.ja`: Use the actual default range
- `ChangeLog`: Add entries

## Verification

- `./configure && make` compiles successfully
- `mlterm --help` and `man mlterm` show the corrected ranges
- `etc/main` / `etc/main.ja` remain valid sample configs